### PR TITLE
Allow hint rotation to be specified in settings

### DIFF
--- a/Settings.plist
+++ b/Settings.plist
@@ -14,5 +14,15 @@
 		<key>Type</key>
 		<string>TextField</string>
 	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<string>true</string>
+		<key>Key</key>
+		<string>rotateHints</string>
+		<key>Title</key>
+		<string>Rotate Hints</string>
+		<key>Type</key>
+		<string>CheckBox</string>
+	</dict>
 </array>
 </plist>

--- a/src/vimmy.css
+++ b/src/vimmy.css
@@ -60,11 +60,13 @@
 	color: #c0392b											!important;
 }
 
-#vimmy-hints span.left {
+#vimmy-hints span.rotated.left {
+	transform-origin: 26px 8px;
 	transform: rotate(20deg);
 }
 
-#vimmy-hints span.right {
+#vimmy-hints span.rotated.right {
+	transform-origin: 0 8px;
 	transform: rotate(20deg);
 }
 

--- a/src/vimmy.html
+++ b/src/vimmy.html
@@ -5,6 +5,7 @@
   // Listen to blacklisted URLs setting changes
   safari.extension.settings.addEventListener( 'change', function( event ) {
     if ( event.key === 'blackListedURLs' && event.newValue ) announceBlackListToAllTabs();
+    if ( event.key === 'rotateHints' && event.newValue ) announceHintRotationToAllTabs();
   }, false );
 
 
@@ -24,6 +25,16 @@
     browserTab.page.dispatchMessage( 'newBlackListedURLs', safari.extension.settings.blackListedURLs.split( ',' ) );
   }
 
+  function announceHintRotationToAllTabs() {
+    safari.application.browserWindows.forEach( function iterateThroughWindows( browserWindow ) {
+      browserWindow.tabs.forEach( announceHintRotationToTab );
+    });
+  }
+
+  function announceHintRotationToTab( browserTab ) {
+    browserTab.page.dispatchMessage( 'newHintRotation', safari.extension.settings.rotateHints );
+  }
+
   // Listen to requests to open a new tab
   var t;
   safari.application.addEventListener( 'message', function( event ) {
@@ -36,6 +47,7 @@
       activatePreviousTab();
     } else if ( event.name == 'ready' ) {
       announceBlackListToTab( event.target );
+      announceHintRotationToTab( event.target );
     } else if ( event.name == 'closeTab' ) {
       closeTab();
     } else if ( event.name == 'reloadTab' ) {

--- a/src/vimmy2.js
+++ b/src/vimmy2.js
@@ -42,6 +42,7 @@
   var
     MODE = 'command',
     FORCE_NEW_TAB = false,
+    ROTATE_HINTS = true,
 
     SCROLL_IS_LOCKED = false,
 
@@ -62,6 +63,7 @@
 
     safari.self.addEventListener( 'message', function handleMessage( event ) {
       if ( event.name === 'newBlackListedURLs' ) checkBlackListStatus( event.message );
+      if ( event.name === 'newHintRotation' ) setHintRotation( event.message );
     });
 
     safari.self.tab.dispatchMessage( 'ready' );
@@ -85,6 +87,11 @@
       if ( expression.test( window.location.href ) ) URL_IS_BLACKLISTED = true;
     }
 
+  }
+
+
+  function setHintRotation( shouldRotateHints ) {
+    ROTATE_HINTS = shouldRotateHints;
   }
 
 
@@ -317,21 +324,22 @@
     // TODO: Attach based on the top of the element, skip the extra calculations!
     var
       bounds = $element.getClientRects()[ 0 ],
-      attachment = ( bounds.left > 40 && bounds.top > 10 ) ? 'left' : 'right';
+      attachment = ( bounds.left > 40 && bounds.top > 10 ) ? 'left' : 'right',
+      rotation = ROTATE_HINTS ? 'rotated' : '';
 
     var
       left,
       top;
 
     if ( attachment === 'left' ) {
-      left = ( bounds.left - ( ( text.length * 8 ) + 14 ) ),
-      top = ( bounds.top + bounds.bottom ) / 2 - 15;
+      left = ( bounds.left - ( ( text.length * 8 ) + 15 ) ),
+      top = ( bounds.top + bounds.bottom ) / 2 - 8;
     } else {
-      left = ( bounds.right ) + 8,
-      top = ( bounds.top + bounds.bottom ) / 2 - 1;
+      left = ( bounds.right ) + 6,
+      top = ( bounds.top + bounds.bottom ) / 2 - 8;
     };
 
-    return $( '<span class="' + attachment + '" style="left: ' + left + 'px; top: ' + top + 'px;">' +
+    return $( '<span class="' + attachment + ' ' + rotation + '" style="left: ' + left + 'px; top: ' + top + 'px;">' +
       '<b>' +  text.split('').join('</b><b>') +
       '</b></span>' );
 


### PR DESCRIPTION
Some users find rotated hints to be a hindrance. This commit allows hint rotation to be turned off. Closes #23.