### PR TITLE
Make SELECT element capture keys

### DIFF
--- a/src/vimmy2.js
+++ b/src/vimmy2.js
@@ -239,6 +239,7 @@
       type = element.getAttribute( 'type' );
 
     if ( tag === 'TEXTAREA' ) return true;
+    if ( tag === 'SELECT' ) return true;
     if ( tag === 'INPUT' && type.isIn( GREEDY_INPUT_TYPES ) ) return true;
     if ( element.contentEditable === 'true' ) return true;
 


### PR DESCRIPTION
This is to avoid reloading the page when a user types "r" to scroll to a value starting with "r" in a select element.

Fixes #29